### PR TITLE
Dancing Steel (Strength) proc does not show

### DIFF
--- a/ShestakUI_Filger/Config/Spells.lua
+++ b/ShestakUI_Filger/Config/Spells.lua
@@ -95,7 +95,7 @@ C["filger_spells"] = {
 			{spellID = 125489, unitID = "player", caster = "player", filter = "BUFF"},
 			-- Physical Melee
 			-- Dancing Steel (Strength)
-			{spellID = 120032, unitID = "player", caster = "player", filter = "BUFF"},
+			{spellID = 120032, unitID = "player", caster = "all", filter = "BUFF"},
 		},
 		{
 			Name = "T_DE/BUFF_BAR",
@@ -2529,7 +2529,7 @@ C["filger_spells"] = {
 			{spellID = 125489, unitID = "player", caster = "player", filter = "BUFF"},
 			-- Physical Melee
 			-- Dancing Steel (Strength)
-			{spellID = 120032, unitID = "player", caster = "player", filter = "BUFF"},
+			{spellID = 120032, unitID = "player", caster = "all", filter = "BUFF"},
 		},
 		{
 			Name = "T_DEBUFF_ICON",


### PR DESCRIPTION
Change caster from "player" to "all" in ShestakUI_Filger/Config/Spells.lua for Dancing Steel (Strength).
