### PR TITLE
ProfessionsTab

### DIFF
--- a/ShestakUI/Modules/Misc/ProfessionTabs.lua
+++ b/ShestakUI/Modules/Misc/ProfessionTabs.lua
@@ -9,7 +9,6 @@ local format = string.format
 local next = next
 local ranks = PROFESSION_RANKS
 local tabs, spells = {}, {}
-local APPRENTICE = "Apprentice"
 
 local handler = CreateFrame("Frame")
 handler:SetScript("OnEvent", function(self, event) self[event](self, event) end)


### PR DESCRIPTION
Would not display professions with a current skill level <= 74. 
Defaults to "Apprentice" when the current skill is <= 74 allowing for the profession to be displayed in the tab.
