### PR TITLE
Update soulshards.lua, removing glyph check

### DIFF
--- a/ShestakUI/Libs/oUF/Elements/SoulShards.lua
+++ b/ShestakUI/Libs/oUF/Elements/SoulShards.lua
@@ -86,12 +86,7 @@ local function Visibility(self, event, unit)
 		end
 
 		if spec == SPEC_WARLOCK_DESTRUCTION then
-			local maxembers = 3
-
-			for i = 1, GetNumGlyphSockets() do
-				local glyphID = select(4, GetGlyphSocketInfo(i))
-				if glyphID == SPEC_WARLOCK_DESTRUCTION_GLYPH_EMBERS then maxembers = 4 end
-			end
+			local maxembers = 4
 
 			for i = 1, maxembers do
 				if i ~= maxembers then
@@ -104,12 +99,7 @@ local function Visibility(self, event, unit)
 
 			if maxembers == 3 then wsb[4]:Hide() else wsb[4]:Show() end
 		elseif spec == SPEC_WARLOCK_AFFLICTION then
-			local maxshards = 3
-
-			for i = 1, GetNumGlyphSockets() do
-				local glyphID = select(4, GetGlyphSocketInfo(i))
-				if glyphID == SPEC_WARLOCK_AFFLICTION_GLYPH_SHARDS then maxshards = 4 end
-			end
+			local maxshards = 4
 
 			for i = 1, maxshards do
 				if i ~= maxshards then


### PR DESCRIPTION
Glyphs are removed from the game, by default warlocks have 4 embers/soulshards
