### PR TITLE
Fixed Restacking

### DIFF
--- a/ShestakUI/Modules/Blizzard/Bags.lua
+++ b/ShestakUI/Modules/Blizzard/Bags.lua
@@ -1235,11 +1235,13 @@ function Stuffing:Restack()
 			if clink then
 				local n, _, _, _, _, _, _, s = GetItemInfo(clink)
 
-				if cnt ~= s then
-					if not st[n] then
-						st[n] = {{item = v, size = cnt, max = s}}
-					else
-						table.insert(st[n], {item = v, size = cnt, max = s})
+				if n ~= nil then
+					if cnt ~= s then
+						if not st[n] then
+							st[n] = {{item = v, size = cnt, max = s}}
+						else
+							table.insert(st[n], {item = v, size = cnt, max = s})
+						end
 					end
 				end
 			end


### PR DESCRIPTION
BattlePets returned nil for itemName and itemStackCount on API GetItemInfo causing the restacking to LUA error.
BattlePets вернулся ноль для ItemName и itemStackCount на API GetItemInfo вызывая переоборудование в LUA ошибки.

Error with "print(clink,cnt,n,s)" as debug in chat
Ошибка с "print(clink,cnt,n,s)", как отлаживать в чате
http://i.imgur.com/rkMXcCw.jpg
