### PR TITLE
Update Functions.lua

### DIFF
--- a/ShestakUI/Core/Functions.lua
+++ b/ShestakUI/Core/Functions.lua
@@ -1004,50 +1004,13 @@ T.UpdateComboPoint = function(self, event, unit)
 	if unit == "pet" then return end
 
 	local cpoints = self.CPoints
-	local cp
-	if UnitHasVehicleUI("player") or UnitHasVehicleUI("vehicle") then
-		cp = GetComboPoints("vehicle", "target")
-	else
-		cp = GetComboPoints("player", "target")
-	end
+	local cp = (UnitHasVehicleUI("player") or UnitHasVehicleUI("vehicle")) and UnitPower("vehicle", 4) or UnitPower("player", 4)
 
 	for i = 1, MAX_COMBO_POINTS do
 		if i <= cp then
 			cpoints[i]:SetAlpha(1)
 		else
 			cpoints[i]:SetAlpha(0.2)
-		end
-	end
-
-	if cpoints[1]:GetAlpha() == 1 then
-		for i = 1, MAX_COMBO_POINTS do
-			cpoints:Show()
-			cpoints[i]:Show()
-		end
-	else
-		for i = 1, MAX_COMBO_POINTS do
-			cpoints:Show()
-			cpoints[i]:Show()
-		end
-	end
-
-	if self.RangeBar then
-		if cpoints[1]:IsShown() and self.RangeBar:IsShown() then
-			cpoints:SetPoint("BOTTOMLEFT", self, "TOPLEFT", 0, 21)
-			if self.Auras then self.Auras:SetPoint("BOTTOMLEFT", self, "TOPLEFT", -2, 33) end
-		elseif cpoints[1]:IsShown() or self.RangeBar:IsShown() then
-			cpoints:SetPoint("BOTTOMLEFT", self, "TOPLEFT", 0, 7)
-			if self.Auras then self.Auras:SetPoint("BOTTOMLEFT", self, "TOPLEFT", -2, 19) end
-		elseif self.Friendship and self.Friendship:IsShown() then
-			if self.Auras then self.Auras:SetPoint("BOTTOMLEFT", self, "TOPLEFT", -2, 19) end
-		else
-			if self.Auras then self.Auras:SetPoint("BOTTOMLEFT", self, "TOPLEFT", -2, 5) end
-		end
-	else
-		if cpoints[1]:IsShown() or (self.Friendship and self.Friendship:IsShown()) then
-			if self.Auras then self.Auras:SetPoint("BOTTOMLEFT", self, "TOPLEFT", -2, 19) end
-		else
-			if self.Auras then self.Auras:SetPoint("BOTTOMLEFT", self, "TOPLEFT", -2, 5) end
 		end
 	end
 end


### PR DESCRIPTION
Patch 6.0.2 (2014-10-14): Combo Points for rogues are now shared across all targets and they are no longer lost when switching targets.
GetComboPoints will return 0 if target is friendly or not found. Use UnitPower(unitId, 4) to get combo points without an enemy targeted.