### PR TITLE
Fixed lingering glow effects in quest tracker

### DIFF
--- a/ShestakUI/Modules/Quests/ObjectiveTracker.lua
+++ b/ShestakUI/Modules/Quests/ObjectiveTracker.lua
@@ -179,6 +179,7 @@ local function SkinBar(line)
 	if not progressBar.styled then
 		bar.BarFrame:Hide()
 		bar.BarGlow:Kill()
+		bar.Sheen:Hide()
 		bar.IconBG:Kill()
 		bar:SetSize(200, 20)
 		bar:SetStatusBarTexture(C.media.texture)


### PR DESCRIPTION
Removing this fixes an issue where the glow effect bugs out and stays active until you reload UI. It's better to just disable it.