### PR TITLE
Skinned Sets Tab

### DIFF
--- a/ShestakUI/Modules/Skins/Blizzard/Collections.lua
+++ b/ShestakUI/Modules/Skins/Blizzard/Collections.lua
@@ -510,6 +510,7 @@ local function LoadSkin()
 	end
 
 	WardrobeCollectionFrame.ItemsCollectionFrame:StripTextures()
+	WardrobeCollectionFrame.SetsTransmogFrame:StripTextures()
 	WardrobeCollectionFrame.progressBar:StripTextures()
 	WardrobeCollectionFrame.progressBar:CreateBackdrop("Overlay")
 	WardrobeCollectionFrame.progressBar:SetStatusBarTexture(C.media.texture)
@@ -521,6 +522,8 @@ local function LoadSkin()
 	T.SkinDropDownBox(WardrobeCollectionFrameWeaponDropDown, 170)
 	T.SkinNextPrevButton(WardrobeCollectionFrame.ItemsCollectionFrame.PagingFrame.PrevPageButton)
 	T.SkinNextPrevButton(WardrobeCollectionFrame.ItemsCollectionFrame.PagingFrame.NextPageButton)
+	T.SkinNextPrevButton(WardrobeCollectionFrame.SetsTransmogFrame.PagingFrame.PrevPageButton)
+	T.SkinNextPrevButton(WardrobeCollectionFrame.SetsTransmogFrame.PagingFrame.NextPageButton)
 
 	WardrobeCollectionFrame.SetsCollectionFrame.LeftInset:StripTextures()
 	WardrobeCollectionFrame.SetsCollectionFrame.RightInset:StripTextures()


### PR DESCRIPTION
There are two sets tab. One, when looking at sets in the interface (that one is skinned). Two, when looking at sets *while using the transmogrifier*. That one was not skinned, this fixed it.