### PR TITLE
remove Light and Fel Infusion from tracking

### DIFF
--- a/ShestakUI/Config/Filters/RaidAuraWatch.lua
+++ b/ShestakUI/Config/Filters/RaidAuraWatch.lua
@@ -116,8 +116,8 @@ T.RaidDebuffs = {
 	[SpellName(236515)] = 3,	-- Shattering Scream
 	[SpellName(236241)] = 3,	-- Soul Rot
 	-- Maiden of Vigilance
-	[SpellName(235213)] = 4,	-- Light Infusion
-	[SpellName(235240)] = 4,	-- Fel Infusion
+	-- [SpellName(235213)] = 4,	-- Light Infusion
+	-- [SpellName(235240)] = 4,	-- Fel Infusion
 	[SpellName(240209)] = 3,	-- Unstable Soul
 	-- Fallen Avatar
 	[SpellName(236494)] = 3,	-- Desolate


### PR DESCRIPTION
В эпохальной сложности важно отхиливать Unstable Soul, которая ощутимо тикает.
Но из-за того, что на всем рейде есть Light или Fel Infusion очень сложно увидеть на ком повесилась бомба и оперативно начать хилить этих людей.
Если пул реквест не пройдет - поменяь приоритет у Unstable Soul - сейчас он почему-то ниже, чем просто информативные Light или Fel Infusion .