### PR TITLE
Filger settings for warrior:

### DIFF
--- a/ShestakUI/Config/Filters/FilgerSpells.lua
+++ b/ShestakUI/Config/Filters/FilgerSpells.lua
@@ -2580,8 +2580,6 @@ C["filger_spells"] = {
 			{spellID = 12292, unitID = "player", caster = "player", filter = "BUFF"},
 			-- Recklesness
 			{spellID = 1719, unitID = "player", caster = "player", filter = "BUFF"},
-			-- Victorious
-			{spellID = 32216, unitID = "player", caster = "player", filter = "BUFF"},
 		},
 		{
 			Name = "P_PROC_ICON",
@@ -2591,7 +2589,9 @@ C["filger_spells"] = {
 			Alpha = 1,
 			IconSize = C.filger.buffs_size,
 			Position = {"TOP", P_PROC_ICON_Anchor},
-
+			
+			-- Victorious
+			{spellID = 32216, unitID = "player", caster = "player", filter = "BUFF"},
 			-- Overpower
 			{spellID = 7384, unitID = "player", caster = "player", filter = "BUFF"},
 			-- Frothing Berserker
@@ -2771,7 +2771,7 @@ C["filger_spells"] = {
 			-- Heroism
 			{spellID = 32182, unitID = "player", caster = "all", filter = "BUFF"},
 			-- Primal Rage [Hunter's pet]
-			{spellID = 264667, unitID = "player", caster = "all", filter = "BUFF"},
+			{spellID = 264667, unitID = "player", caster = "all", filter = "BUFF", absID = true},
 			-- Time Warp
 			{spellID = 80353, unitID = "player", caster = "all", filter = "BUFF"},
 			-- Drums of Fury


### PR DESCRIPTION
-'Victorious' moved to proc section;
-fixed 'Enrage' double display (through 'Primal Rage [Hunter's pet]').