### PR TITLE
Removed double Rune of Power

### DIFF
--- a/ShestakUI/Config/Filters/FilgerSpells.lua
+++ b/ShestakUI/Config/Filters/FilgerSpells.lua
@@ -813,7 +813,7 @@ C["filger_spells"] = {
 			-- Temporal Shield
 			{spellID = 198111, unitID = "player", caster = "player", filter = "BUFF"},
 			-- Rune of Power
-			{spellID = 116014, unitID = "player", caster = "player", filter = "BUFF"},
+			{spellID = 116011, filter = "ICD", trigger = "NONE", totem = true},
 			-- Mirror Image
 			{spellID = 55342, filter = "ICD", trigger = "NONE", duration = 40},
 			-- Icicles
@@ -843,8 +843,6 @@ C["filger_spells"] = {
 			{spellID = 269651, unitID = "player", caster = "player", filter = "BUFF"},
 			-- Clearcasting
 			{spellID = 263725, unitID = "player", caster = "player", filter = "BUFF"},
-			-- Rune of Power
-			{spellID = 116011, filter = "ICD", trigger = "NONE", totem = true},
 		},
 		{
 			Name = "T_DEBUFF_ICON",


### PR DESCRIPTION
There were two Rune of Power. Moved the one with duration into buffs, because it's a buff and not a proc.